### PR TITLE
feat(script): add xaitk_demo poetry script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,4 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 black = "black:main"
+xaitk_demo = "xaitk_demo:main"

--- a/xaitk_demo/__init__.py
+++ b/xaitk_demo/__init__.py
@@ -1,1 +1,9 @@
 __version__ = "0.1.0"
+
+
+def main():
+    from trame import start
+    from xaitk_demo.core import initialize
+    from xaitk_demo.ui import layout
+
+    start(layout, on_ready=initialize)

--- a/xaitk_demo/__main__.py
+++ b/xaitk_demo/__main__.py
@@ -1,5 +1,3 @@
-from trame import start
-from xaitk_demo.core import initialize
-from xaitk_demo.ui import layout
+from xaitk_demo import main
 
-start(layout, on_ready=initialize)
+main()


### PR DESCRIPTION
This allows the program to be started by either `xaitk_demo` or `python -m xaitk_demo`.