### PR TITLE
Fix choice of device and allow use of GPU

### DIFF
--- a/xaitk_saliency_demo/app/engine/ml_models.py
+++ b/xaitk_saliency_demo/app/engine/ml_models.py
@@ -37,6 +37,7 @@ DEVICE = torch.device("cpu")
 
 
 def update_ml_device(cpu_only=True):
+    global DEVICE
     if not cpu_only and torch.cuda.is_available():
         DEVICE = torch.device("cuda")
         logger.info(" ~~~ Using GPU ~~~ \n")
@@ -75,7 +76,9 @@ RetinaNet.postprocess_detections = retinanet_postprocess_detections
 
 
 class AbstractModel:
-    def __init__(self, server, model, device=DEVICE):
+    def __init__(self, server, model, device=None):
+        if device is None:
+            device = DEVICE
         self._server = server
         self._device = device
         self.topk = 10


### PR DESCRIPTION
@jourdain I noticed that the app was never using the GPU, even if available and the `--cpu flag` is set to False. I'm not sure my approach is the best way to do this, but I set the device dynamically when the model is created. There might be a cleaner way to do this using globals, but I couldn't figure it out. This also affects the trame-mnist app too.