### PR TITLE
Update README to use pip install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,6 @@ venv creation for AI
 
     conda create --name xaitk python=3.9 -y
     conda activate xaitk
-    conda install "pytorch==1.9.1" "torchvision==0.10.1" -c pytorch -y
-    conda install scipy "scikit-learn==0.24.2" "scikit-image==0.18.3" -c conda-forge -y
 
     # For development when inside repo
     pip install -e .


### PR DESCRIPTION
In the process of testing `xaitk-saliency-demo`, I had to create a fresh virtual environment (Ubuntu 20.04). Following the current installation instructions resulted in an import error with the `scipy` package (probably due to some version conflicts between `conda` and `pip`). Using the `pip` only install seems to be simpler and cleaner, so I have edited the README accordingly.

Related to this, it might make sense to update the pypi package for users who do not want an editable install.